### PR TITLE
Fix non static method should not be called statically

### DIFF
--- a/prestashop1.6/tawkto.php
+++ b/prestashop1.6/tawkto.php
@@ -229,7 +229,7 @@ class Tawkto extends Module
      *
      * @return array[string]string
      */
-    public function getPropertyAndWidget()
+    public static function getPropertyAndWidget()
     {
         $current_widget = Configuration::get(self::TAWKTO_SELECTED_WIDGET);
         if (empty($current_widget)) {

--- a/prestashop1.7/tawkto.php
+++ b/prestashop1.7/tawkto.php
@@ -243,7 +243,7 @@ class Tawkto extends Module
      *
      * @return array[string]string
      */
-    public function getPropertyAndWidget()
+    public static function getPropertyAndWidget()
     {
         $current_widget = Configuration::get(self::TAWKTO_SELECTED_WIDGET);
         if (empty($current_widget)) {


### PR DESCRIPTION
fixes #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `getPropertyAndWidget` method can now be called statically on the `TawkTo` class in both PrestaShop 1.6 and 1.7, enhancing flexibility in usage.
  
- **Bug Fixes**
	- No specific bug fixes were reported in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->