### PR TITLE
Update version supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "license": "AFL-3.0",
     "scripts": {
-        "post-install-cmd": "[ -z \"$GITHUB_ACTIONS\" ] && npm install",
+        "post-install-cmd": "if [ -z \"$GITHUB_ACTIONS\" ]; then npm install; fi",
         "lint": "phpcs -p -s -v --runtime-set ignore_warnings_on_exit true .",
         "lint:fix": "php-cs-fixer fix --config='.php-cs-fixer.dist.php'",
         "auto-index": "composer run auto-index:1.6 && composer run auto-index:1.7 && composer run auto-index:8",

--- a/prestashop1.6/config.xml
+++ b/prestashop1.6/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>tawkto</name>
 	<displayName><![CDATA[tawk.to]]></displayName>
-	<version><![CDATA[1.4.0]]></version>
+	<version><![CDATA[1.5.0]]></version>
 	<description><![CDATA[tawk.to live chat integration.]]></description>
 	<author><![CDATA[tawk.to]]></author>
 	<tab><![CDATA[front_office_features]]></tab>

--- a/prestashop1.6/tawkto.php
+++ b/prestashop1.6/tawkto.php
@@ -45,7 +45,7 @@ class Tawkto extends Module
     {
         $this->name = 'tawkto';
         $this->tab = 'front_office_features';
-        $this->version = '1.4.0';
+        $this->version = '1.5.0';
         $this->author = 'tawk.to';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '1.6'];

--- a/prestashop1.6/views/templates/hook/widget.tpl
+++ b/prestashop1.6/views/templates/hook/widget.tpl
@@ -15,7 +15,7 @@
  * @copyright Copyright (c) 2014-2024 tawk.to
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *}
-<!--Start of Tawk.to Script (1.4.0)-->
+<!--Start of Tawk.to Script (1.5.0)-->
 <script type="text/javascript">
 var $_Tawk_API={},$_Tawk_LoadStart=new Date();
 (function(){

--- a/prestashop1.7/config.xml
+++ b/prestashop1.7/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>tawkto</name>
     <displayName><![CDATA[tawk.to]]></displayName>
-    <version><![CDATA[1.4.0]]></version>
+    <version><![CDATA[1.5.0]]></version>
     <description><![CDATA[tawk.to live chat integration.]]></description>
     <author><![CDATA[tawk.to]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/prestashop1.7/tawkto.php
+++ b/prestashop1.7/tawkto.php
@@ -45,7 +45,7 @@ class Tawkto extends Module
     {
         $this->name = 'tawkto';
         $this->tab = 'front_office_features';
-        $this->version = '1.4.0';
+        $this->version = '1.5.0';
         $this->author = 'tawk.to';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '1.7'];

--- a/prestashop1.7/views/templates/hook/widget.tpl
+++ b/prestashop1.7/views/templates/hook/widget.tpl
@@ -15,7 +15,7 @@
  * @copyright Copyright (c) 2014-2024 tawk.to
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *}
-<!--Start of tawk.to Script (1.4.0)-->
+<!--Start of tawk.to Script (1.5.0)-->
 <script type="text/javascript">
 var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
 

--- a/prestashop8.x/config.xml
+++ b/prestashop8.x/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>tawkto</name>
     <displayName><![CDATA[tawk.to]]></displayName>
-    <version><![CDATA[1.4.0]]></version>
+    <version><![CDATA[1.5.0]]></version>
     <description><![CDATA[tawk.to live chat integration.]]></description>
     <author><![CDATA[tawk.to]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/prestashop8.x/tawkto.php
+++ b/prestashop8.x/tawkto.php
@@ -44,7 +44,7 @@ class Tawkto extends Module
     {
         $this->name = 'tawkto';
         $this->tab = 'front_office_features';
-        $this->version = '1.4.0';
+        $this->version = '1.5.0';
         $this->author = 'tawk.to';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '8.2.99'];

--- a/prestashop8.x/tawkto.php
+++ b/prestashop8.x/tawkto.php
@@ -47,7 +47,7 @@ class Tawkto extends Module
         $this->version = '1.4.0';
         $this->author = 'tawk.to';
         $this->need_instance = 0;
-        $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '8.1.99'];
+        $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '8.2.99'];
 
         parent::__construct();
 

--- a/prestashop8.x/views/templates/hook/widget.tpl
+++ b/prestashop8.x/views/templates/hook/widget.tpl
@@ -15,7 +15,7 @@
  * @copyright Copyright (c) 2014-2024 tawk.to
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *}
-<!--Start of tawk.to Script (1.4.0)-->
+<!--Start of tawk.to Script (1.5.0)-->
 <script type="text/javascript">
 var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
 


### PR DESCRIPTION
fixes #42 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated the Tawkto module version to 1.5.0 across all supported PrestaShop versions.
	- Extended the compatibility range for the Tawkto module to support PrestaShop versions up to 8.2.99.
- **Bug Fixes**
	- Updated the Tawk.to script version in widget templates to reflect the new module version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->